### PR TITLE
update link to cdktf-provider-project

### DIFF
--- a/src/readme.ts
+++ b/src/readme.ts
@@ -54,7 +54,7 @@ This is mostly based on [projen](https://github.com/eladb/projen), which takes c
 
 ## cdktf-provider-project based on projen
 
-There's a custom [project builder](https://github.com/skorfmann/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` providers.
+There's a custom [project builder](https://github.com/terraform-cdk-providers/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` providers.
 
 ## provider version
 


### PR DESCRIPTION
Just noticed that the link still pointed to the now archived repo.

I don't know why the Github UI appended a newline when editing the file. Feel free to remove it.