### PR TITLE
Update cdktf version to a more flexible semvar.

### DIFF
--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -13,7 +13,7 @@ export class CdktfConfig {
   constructor(project: JsiiProject, options: CdktfConfigOptions) {
     const { terraformProvider, providerName } = options;
 
-    const cdktfVersion = '^0.1';
+    const cdktfVersion = '^0.x';
 
     project.addPeerDeps(`cdktf@${cdktfVersion}`);
     project.addPeerDeps('constructs@^3.0.4');


### PR DESCRIPTION
cdktf has been on version `0.2.0`, as of 21 days ago , and recently got bumped up to` 0.2.1`.

Using `^0.1` locks semvar resolution to version `0.1.0 - 0.1.9`

Anyone who wants to use the prebuilt providers with the latest cdktf release, can end up in dependency `warning` hell.

Using `^0.x` locks semvar resolution to version `0.0.0` - `< 1.0.0`.

IMO, it's a fair play to allow the flexibility of the lib, especially before a 1.0 release, we can go back to locking on major/minor versions once 1.0 is released.
Moving fast and breaking things is a lifestyle, especially in pre 1.0 land  :)

Not to mention, having the GitHub action workflows is a safety net for breaking changes, so any provider using this package as a base wouldn't really be at risk of being unexpectedly updated and affecting downstream consumers.

....but maybe I'm missing something, and welcome any enlightenment. 
