### PR TITLE
Use explicit version range

### DIFF
--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -13,7 +13,7 @@ export class CdktfConfig {
   constructor(project: JsiiProject, options: CdktfConfigOptions) {
     const { terraformProvider, providerName } = options;
 
-    const cdktfVersion = '^0.x';
+    const cdktfVersion = '^0.2';
 
     project.addPeerDeps(`cdktf@${cdktfVersion}`);
     project.addPeerDeps('constructs@^3.0.4');

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,14 +716,6 @@
     "@typescript-eslint/typescript-estree" "4.22.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.21.0.tgz#c81b661c4b8af1ec0c010d847a8f9ab76ab95b4d"
-  integrity sha512-kfOjF0w1Ix7+a5T1knOw00f7uAP9Gx44+OEsNQi0PvvTPLYeXJlsCJ4tYnDj5PQEYfpcgOH5yBlw7K+UEI9Agw==
-  dependencies:
-    "@typescript-eslint/types" "4.21.0"
-    "@typescript-eslint/visitor-keys" "4.21.0"
-
 "@typescript-eslint/scope-manager@4.22.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz#ed411545e61161a8d702e703a4b7d96ec065b09a"
@@ -732,28 +724,10 @@
     "@typescript-eslint/types" "4.22.0"
     "@typescript-eslint/visitor-keys" "4.22.0"
 
-"@typescript-eslint/types@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.21.0.tgz#abdc3463bda5d31156984fa5bc316789c960edef"
-  integrity sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==
-
 "@typescript-eslint/types@4.22.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
   integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
-
-"@typescript-eslint/typescript-estree@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.21.0.tgz#3817bd91857beeaeff90f69f1f112ea58d350b0a"
-  integrity sha512-ZD3M7yLaVGVYLw4nkkoGKumb7Rog7QID9YOWobFDMQKNl+vPxqVIW/uDk+MDeGc+OHcoG2nJ2HphwiPNajKw3w==
-  dependencies:
-    "@typescript-eslint/types" "4.21.0"
-    "@typescript-eslint/visitor-keys" "4.21.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.22.0":
   version "4.22.0"
@@ -767,14 +741,6 @@
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.21.0.tgz#990a9acdc124331f5863c2cf21c88ba65233cd8d"
-  integrity sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==
-  dependencies:
-    "@typescript-eslint/types" "4.21.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.22.0":
   version "4.22.0"


### PR DESCRIPTION
There are issues with defining the version like `^0` / `<1` / `0.x` when
building packages for nuget. Haven't fully grasped what the issue is, a
fix should be done in [jsii-pacmak](https://github.com/aws/jsii/blob/3e154b5c558f87a791322607b424ff53556a98fe/packages/jsii-pacmak). In general, it should be [supported](https://github.com/aws/jsii/blob/3e154b5c558f87a791322607b424ff53556a98fe/packages/jsii-pacmak/test/targets/version-utils.test.ts)

The version schema for nuget is here https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges-and-wildcards

The error we're seeing:

```
/tmp/npm-packf3Ti8l/HashiCorp.Cdktf.Providers.Aws/HashiCorp.Cdktf.Providers.Aws.csproj : warning NU1604: Project dependency HashiCorp.Cdktf (<= 0.999.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results
```

for the following config file

```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <!-- Package Identification -->
    <Description>Prebuilt aws Provider for Terraform CDK (cdktf) (Stability: Stable)</Description>
    <PackageId>HashiCorp.Cdktf.Providers.Aws</PackageId>
    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
    <PackageVersion>1.0.40</PackageVersion>
    <!-- Additional Metadata -->
    <Authors>HashiCorp</Authors>
    <Company>HashiCorp</Company>
    <PackageTags>aws;cdk;cdktf;provider;terraform</PackageTags>
    <Language>en-US</Language>
    <ProjectUrl>https://github.com/terraform-cdk-providers/cdktf-provider-aws.git</ProjectUrl>
    <RepositoryUrl>https://github.com/terraform-cdk-providers/cdktf-provider-aws.git</RepositoryUrl>
    <RepositoryType>git</RepositoryType>
    <!-- Build Configuration -->
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
    <IncludeSymbols>true</IncludeSymbols>
    <IncludeSource>true</IncludeSource>
    <Nullable>enable</Nullable>
    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
    <TargetFramework>netcoreapp3.1</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <EmbeddedResource Include="cdktf-provider-aws-1.0.40.tgz" />
  </ItemGroup>
  <ItemGroup>
    <PackageReference Include="Amazon.JSII.Runtime" Version="[1.27.0,2.0.0)" />
    <PackageReference Include="HashiCorp.Cdktf" Version="(,0.999.0]" />
    <PackageReference Include="Constructs" Version="[3.0.4,4.0.0)" />
  </ItemGroup>
  <PropertyGroup>
    <!-- Silence [Obsolete] warnings -->
    <NoWarn>0612,0618</NoWarn>
    <!-- Treat warnings symptomatic of code generation bugs as errors -->
    <WarningsAsErrors>0108,0109</WarningsAsErrors>
  </PropertyGroup>
</Project>
```